### PR TITLE
feat: document schema, mutation and service created.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.19.2",
     "express-graphql": "^0.12.0",
     "graphql": "^16.8.1",
+    "graphql-upload-ts": "^2.1.2",
     "helmet": "^7.1.0",
     "http-errors": "~2.0.0",
     "morgan": "~1.10.0"

--- a/src/api/v1/graphql.ts
+++ b/src/api/v1/graphql.ts
@@ -1,4 +1,4 @@
-import { GraphQLResolveInfo } from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
@@ -15,6 +15,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  Upload: { input: any; output: any; }
 };
 
 export type CreateDeviceInput = {
@@ -27,6 +28,13 @@ export type CreateDeviceInput = {
    * represented by its UUID and description, to a reMarkable Cloud account.
    */
   oneTimeCode: Scalars['String']['input'];
+};
+
+export type CreateDocumentInput = {
+  /** Document file data buffer */
+  buffer: Scalars['Upload']['input'];
+  /** Document name */
+  name: Scalars['String']['input'];
 };
 
 export type Device = {
@@ -51,6 +59,13 @@ export enum DeviceDescription {
   Remarkable = 'remarkable'
 }
 
+/** reMarkable Cloud API document */
+export type Document = {
+  __typename?: 'Document';
+  id?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   /**
@@ -59,8 +74,10 @@ export type Mutation = {
    * associated with the `one-time` code.
    */
   createDevice?: Maybe<Device>;
+  /** Uploads a new `document` to a reMarkable Cloud account. */
+  createDocument?: Maybe<Document>;
   /**
-   * Creates new `device` session. Returns a `device` session token that
+   * Creates a new `device` session. Returns a `device` session token that
    * must be included in all request `headers` as a `Bearer` token.
    *
    * Once expired, the `device` session token must be renewed to continue
@@ -72,6 +89,11 @@ export type Mutation = {
 
 export type MutationCreateDeviceArgs = {
   input: CreateDeviceInput;
+};
+
+
+export type MutationCreateDocumentArgs = {
+  input: CreateDocumentInput;
 };
 
 export type Query = {
@@ -169,23 +191,29 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = {
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   CreateDeviceInput: CreateDeviceInput;
+  CreateDocumentInput: CreateDocumentInput;
   Device: ResolverTypeWrapper<Device>;
   DeviceDescription: DeviceDescription;
+  Document: ResolverTypeWrapper<Document>;
   Mutation: ResolverTypeWrapper<{}>;
   Query: ResolverTypeWrapper<{}>;
   Session: ResolverTypeWrapper<Session>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
+  Upload: ResolverTypeWrapper<Scalars['Upload']['output']>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Boolean: Scalars['Boolean']['output'];
   CreateDeviceInput: CreateDeviceInput;
+  CreateDocumentInput: CreateDocumentInput;
   Device: Device;
+  Document: Document;
   Mutation: {};
   Query: {};
   Session: Session;
   String: Scalars['String']['output'];
+  Upload: Scalars['Upload']['output'];
 };
 
 export type DeviceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Device'] = ResolversParentTypes['Device']> = {
@@ -195,8 +223,15 @@ export type DeviceResolvers<ContextType = any, ParentType extends ResolversParen
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type DocumentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Document'] = ResolversParentTypes['Document']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createDevice?: Resolver<Maybe<ResolversTypes['Device']>, ParentType, ContextType, RequireFields<MutationCreateDeviceArgs, 'input'>>;
+  createDocument?: Resolver<Maybe<ResolversTypes['Document']>, ParentType, ContextType, RequireFields<MutationCreateDocumentArgs, 'input'>>;
   createSession?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>;
 };
 
@@ -210,10 +245,16 @@ export type SessionResolvers<ContextType = any, ParentType extends ResolversPare
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload';
+}
+
 export type Resolvers<ContextType = any> = {
   Device?: DeviceResolvers<ContextType>;
+  Document?: DocumentResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Session?: SessionResolvers<ContextType>;
+  Upload?: GraphQLScalarType;
 };
 

--- a/src/api/v1/introspection.json
+++ b/src/api/v1/introspection.json
@@ -78,6 +78,49 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CreateDocumentInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buffer",
+            "description": "Document file data buffer",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Upload",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Document name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Device",
         "description": null,
@@ -173,6 +216,41 @@
       },
       {
         "kind": "OBJECT",
+        "name": "Document",
+        "description": "reMarkable Cloud API document",
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
         "fields": [
@@ -206,8 +284,37 @@
             "deprecationReason": null
           },
           {
+            "name": "createDocument",
+            "description": "Uploads a new `document` to a reMarkable Cloud account.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateDocumentInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Document",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createSession",
-            "description": "Creates new `device` session. Returns a `device` session token that\nmust be included in all request `headers` as a `Bearer` token.\n\nOnce expired, the `device` session token must be renewed to continue\ninteracting with the reMarkable Cloud API.",
+            "description": "Creates a new `device` session. Returns a `device` session token that\nmust be included in all request `headers` as a `Bearer` token.\n\nOnce expired, the `device` session token must be renewed to continue\ninteracting with the reMarkable Cloud API.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -285,6 +392,16 @@
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Upload",
+        "description": "The `Upload` scalar type represents a file upload.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,

--- a/src/api/v1/resolvers.ts
+++ b/src/api/v1/resolvers.ts
@@ -1,8 +1,11 @@
 import { type Resolvers, type ResolversTypes } from './graphql'
 import { createDevice } from './services/deviceServices'
 import { createSession } from './services/sessionServices'
+import { createDocument } from './services/documentServices'
+import { GraphQLUpload } from 'graphql-upload-ts'
 
 export const resolvers: Resolvers = {
+  Upload: GraphQLUpload,
   Query: {
     hello: (): string => {
       return 'Hello, world!'
@@ -15,6 +18,10 @@ export const resolvers: Resolvers = {
     createSession: async (parent, args, context): Promise<ResolversTypes['Session']> => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return await createSession(context.token)
+    },
+    createDocument: async (_, { input }: { input: ResolversTypes['CreateDocumentInput'] }, context): Promise<ResolversTypes['Document']> => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      return await createDocument(input, context.token)
     }
   }
 }

--- a/src/api/v1/schema.graphql
+++ b/src/api/v1/schema.graphql
@@ -1,3 +1,8 @@
+"""
+File buffer
+"""
+scalar Upload
+
 enum DeviceDescription {
 	"""
 	Device running in a Chrome browser
@@ -51,6 +56,14 @@ type Session {
 	expiresAt: String
 }
 
+"""
+reMarkable Cloud API document
+"""
+type Document {
+	id: String
+	name: String
+}
+
 type Query {
 	hello: String
 }
@@ -71,6 +84,17 @@ input CreateDeviceInput {
 	oneTimeCode: String!
 }
 
+input CreateDocumentInput {
+	"""
+	Document name
+	"""
+	name: String!
+	"""
+	Document file data buffer
+	"""
+	buffer: Upload!
+}
+
 type Mutation {
 	"""
 	Given a Device information and a `one-time` code, creates a new `device`
@@ -79,11 +103,15 @@ type Mutation {
 	"""
 	createDevice(input: CreateDeviceInput!): Device
 	"""
-	Creates new `device` session. Returns a `device` session token that
+	Creates a new `device` session. Returns a `device` session token that
 	must be included in all request `headers` as a `Bearer` token.
 
 	Once expired, the `device` session token must be renewed to continue
 	interacting with the reMarkable Cloud API.
 	"""
 	createSession: Session
+	"""
+	Uploads a new `document` to a reMarkable Cloud account.
+	"""
+	createDocument(input: CreateDocumentInput!): Document
 }

--- a/src/api/v1/serializers/documentSerializers.ts
+++ b/src/api/v1/serializers/documentSerializers.ts
@@ -1,0 +1,41 @@
+import { type ResolversTypes } from '../graphql'
+
+export async function deserializeCreateDocumentInput (documentInput: ResolversTypes['CreateDocumentInput']): Promise<any> {
+  function name (documentInput): string {
+    return documentInput.name
+  }
+
+  async function buffer (documentInput): Promise<any> {
+    const { createReadStream } = await documentInput.buffer
+    const stream = createReadStream()
+    const data = []
+
+    return new Promise((resolve, reject) => {
+      stream.on('data', chunk => { data.push(chunk) })
+
+      stream.on('end', async () => { resolve(Buffer.concat(data)) })
+
+      stream.on('error', reject)
+    })
+  }
+
+  return {
+    name: name(documentInput),
+    buffer: await buffer(documentInput)
+  }
+}
+
+export function serializeDocument (document): ResolversTypes['Document'] {
+  function id (document): string {
+    return 'id'
+  }
+
+  function name (document): string {
+    return 'name'
+  }
+
+  return {
+    id: id(document),
+    name: name(document)
+  }
+}

--- a/src/api/v1/services/documentServices.ts
+++ b/src/api/v1/services/documentServices.ts
@@ -1,0 +1,20 @@
+import { Device, FileBuffer, ServiceManager } from 'a-remarkable-js-sdk'
+import { type ResolversTypes } from '../graphql'
+import { deserializeCreateDocumentInput, serializeDocument } from '../serializers/documentSerializers'
+
+export async function createDocument (documentInput: ResolversTypes['CreateDocumentInput'], deviceToken: string): Promise<ResolversTypes['Document']> {
+  const deserializedDocumentInput = await deserializeCreateDocumentInput(documentInput)
+
+  const device = new Device(deviceToken)
+  await device.connect()
+  const serviceManager = new ServiceManager(device)
+
+  const file = new FileBuffer(
+    deserializedDocumentInput.name as string,
+    deserializedDocumentInput.buffer as ArrayBuffer,
+    serviceManager
+  )
+
+  const fileUpload = await file.upload()
+  return serializeDocument(fileUpload)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,6 +3523,15 @@ graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
+graphql-upload-ts@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-upload-ts/-/graphql-upload-ts-2.1.2.tgz#5312b56ff75184fc9fabf1d510d11c88f9d61241"
+  integrity sha512-g0mL/55NI1MzRrTczIJw1cruIrqlUm7liQRkuGl6l9s4/j0aSuPkvZ52BS7teI43g6KXE/NeDyUotEAiTyZdHw==
+  dependencies:
+    busboy "^1.6.0"
+    http-errors "^2.0.0"
+    object-path "^0.11.8"
+
 graphql-ws@^5.14.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.16.0.tgz#849efe02f384b4332109329be01d74c345842729"
@@ -3603,7 +3612,7 @@ http-errors@1.8.0:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@2.0.0, http-errors@~2.0.0:
+http-errors@2.0.0, http-errors@^2.0.0, http-errors@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
   integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
@@ -4362,6 +4371,11 @@ object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-path@^0.11.8:
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
+  integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
 
 object.assign@^4.1.5:
   version "4.1.5"


### PR DESCRIPTION
I use the `graphql-upload-ts` to enable file uploading to the server. The package adds a new Middleware for file uploading in requests, and a new `Upload` scalar.

Once this is set, we can read the stream from the `Upload` input and generate from there the `Buffer` which is then used to upload the file to reMarkable.

In the Apollo Studio, you can test this feature by adding a file with a key pointing to the corresponding input field containing the `Upload` payload, and then adding an `x-apollo-operation-name` header with the name of the operation.

In this case, if I want to upload a sample file I need to set my variables as:

```
{
  "input": {
    "name": "mydocument",
    "buffer": null
  }
}
```

And the uploaded file with the key: `input.buffer`.

There might be adjustments to be made in production, but for now this is working properly.